### PR TITLE
Use rela relocation for riscv64 when resolve gnu ifunc

### DIFF
--- a/libc/bionic/libc_init_static.cpp
+++ b/libc/bionic/libc_init_static.cpp
@@ -72,7 +72,7 @@ static void call_array(init_func_t** list, int argc, char* argv[], char* envp[])
   }
 }
 
-#if defined(__aarch64__) || defined(__x86_64__)
+#if defined(__aarch64__) || defined(__x86_64__) || (defined(__riscv) && (__riscv_xlen == 64))
 extern __LIBC_HIDDEN__ __attribute__((weak)) ElfW(Rela) __rela_iplt_start[], __rela_iplt_end[];
 
 static void call_ifunc_resolvers() {


### PR DESCRIPTION
Add riscv64 micro definition before call_ifunc_resolvers function