### PR TITLE
clean-up some minor faults

### DIFF
--- a/libc/Android.bp
+++ b/libc/Android.bp
@@ -1862,6 +1862,7 @@ genrule {
     srcs: ["libc.map.txt"],
     tool_files: [":bionic-generate-version-script"],
     cmd: "$(location :bionic-generate-version-script) riscv64 $(in) $(out)",
+    bazel_module: { bp2build_available: true },
 }
 
 genrule {
@@ -1967,7 +1968,7 @@ cc_library_headers {
             export_system_include_dirs: ["kernel/uapi/asm-arm64"],
         },
         riscv64: {
-            export_include_dirs: ["kernel/uapi/asm-riscv",],
+            export_system_include_dirs: ["kernel/uapi/asm-riscv"],
         },
         x86: {
             export_system_include_dirs: ["kernel/uapi/asm-x86"],
@@ -2446,6 +2447,8 @@ cc_object {
         "kernel/uapi/asm-riscv",
         "kernel/uapi",
     ],
+
+    bazel_module: { bp2build_available: true },
 }
 
 cc_object {

--- a/linker/Android.bp
+++ b/linker/Android.bp
@@ -474,9 +474,6 @@ cc_library {
         x86_64: {
             ldflags: ["-Wl,--exclude-libs=libgcc_eh.a"],
         },
-        riscv64: {
-            version_script: "linker.generic.map",
-        },
     },
 
     srcs: ["ld_android.cpp"],

--- a/tests/Android.bp
+++ b/tests/Android.bp
@@ -207,7 +207,7 @@ cc_prebuilt_test_library_shared {
             srcs: ["prebuilt-elf-files/arm64/libtest_invalid-empty_shdr_table.so"],
         },
         riscv64: {
-            srcs: ["prebuilt-elf-files/arm64/libtest_invalid-empty_shdr_table.so"],
+            srcs: ["prebuilt-elf-files/riscv64/libtest_invalid-empty_shdr_table.so"],
         },
         x86: {
             srcs: ["prebuilt-elf-files/x86/libtest_invalid-empty_shdr_table.so"],

--- a/tools/versioner/src/Arch.h
+++ b/tools/versioner/src/Arch.h
@@ -125,6 +125,7 @@ static const std::set<Arch> supported_archs = {
   Arch::arm64,
   Arch::x86,
   Arch::x86_64,
+  Arch::riscv64,
 };
 
 static ArchMap<std::string> arch_targets = {


### PR DESCRIPTION
Some minor changes.

Passed built and run with following commands:
```
lunch sdk_phone64_riscv64
m -j
emulator -no-qt -show-kernel -noaudio -selinux permissive -qemu -smp 1 -m 3584M -bios kernel/prebuilts/5.10/riscv64/fw_jump.bin
```

Signed-off-by: Chen Wang <wangchen20@iscas.ac.cn>