### PR TITLE
fix android unsafe frame pointer chase

### DIFF
--- a/libc/bionic/android_unsafe_frame_pointer_chase.cpp
+++ b/libc/bionic/android_unsafe_frame_pointer_chase.cpp
@@ -72,7 +72,11 @@ __attribute__((no_sanitize("address", "hwaddress"))) size_t android_unsafe_frame
 
   size_t num_frames = 0;
   while (1) {
+#if (defined(__riscv) && (__riscv_xlen == 64))
+    auto* frame = reinterpret_cast<frame_record*>(begin - 16);
+#else
     auto* frame = reinterpret_cast<frame_record*>(begin);
+#endif
     if (num_frames < num_entries) {
       buf[num_frames] = __bionic_clear_pac_bits(frame->return_addr);
     }

--- a/libc/seccomp/seccomp_policy.cpp
+++ b/libc/seccomp/seccomp_policy.cpp
@@ -31,7 +31,7 @@
 
 #if defined __arm__ || defined __aarch64__
 
-//#define DUAL_ARCH
+#define DUAL_ARCH
 #define PRIMARY_ARCH AUDIT_ARCH_AARCH64
 static const struct sock_filter* primary_app_filter = arm64_app_filter;
 static const size_t primary_app_filter_size = arm64_app_filter_size;


### PR DESCRIPTION
This PR includes two commits:
- 8db7ad97d2d07e5c06559cd2e93f426cd208c251
- 493a19328bfb84591af0d1302e8b9fe9fe723e2e

Both pass build with sdk_phone64_riscv64 and can run on emulator.
