### PR TITLE
minor bugfixes in fenv

### DIFF
--- a/libc/include/bits/fenv_riscv64.h
+++ b/libc/include/bits/fenv_riscv64.h
@@ -43,10 +43,17 @@ typedef unsigned int fenv_t;
 #define FE_INVALID    0x10
 #define FE_ALL_EXCEPT (FE_DIVBYZERO | FE_INEXACT | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW)
 
-/* Rounding modes. */
+/*
+ * Rounding modes.
+ * Currently, we have not supported FE_TOMM (Round to Nearest, ties to Max Magnitude).
+ */
 #define FE_TONEAREST  0x0
 #define FE_TOWARDZERO 0x1
 #define FE_DOWNWARD   0x2
 #define FE_UPWARD     0x3
+#define FE_TOMM       0x4
+
+#define FE_ROUNDMODE_MIN FE_TONEAREST
+#define FE_ROUNDMODE_MAX FE_UPWARD
 
 __END_DECLS

--- a/libm/riscv64/fenv.c
+++ b/libm/riscv64/fenv.c
@@ -29,8 +29,8 @@
 #include <stdint.h>
 #include <fenv.h>
 
-# define __get_fcw(cw) __asm__ volatile ("frsr %0" : "=r" (cw))
-# define __set_fcw(cw) __asm__ volatile ("fssr %z0" : : "r" (cw))
+# define __get_fcw(cw) __asm__ volatile ("frcsr %0" : "=r" (cw))
+# define __set_fcw(cw) __asm__ volatile ("fscsr %z0" : : "r" (cw))
 
 const fenv_t __fe_dfl_env = 0;
 
@@ -95,7 +95,9 @@ int fegetround(void)
 
 int fesetround(int round)
 {
-  round &= FE_UPWARD;
+  if (round < FE_ROUNDMODE_MIN || round > FE_ROUNDMODE_MAX) {
+    return -1;
+  }
   asm volatile ("fsrm %z0" : : "r" (round));
   return 0;
 }


### PR DESCRIPTION
minor bugfixes in fenv
    
- rename obsoleted frsr/fssr instruction name to new frcsr/fscsr
- remove the extra rounding mode filtering in fesetround()
    
Signed-off-by: liushuyu <liushuyu011@gmail.com>
Signed-off-by: Chen Wang <wangchen20@iscas.ac.cn>