### PR TITLE
using 0x0001(c.addi) as padding bytes

### DIFF
--- a/libc/arch-riscv64/generic/bionic/memcpy.S
+++ b/libc/arch-riscv64/generic/bionic/memcpy.S
@@ -3,7 +3,7 @@
 #include <private/bionic_asm.h>
 
 #  define LABLE_ALIGN   \
-        .balignw 16, 0x00000013
+        .balignw 16, 0x00000001
 
 ENTRY(memcpy_generic)
 .L_to_memcpy:


### PR DESCRIPTION
Details please refer to:
https://github.com/riscv-android-src/platform-bionic/issues/22

Signed-off-by: Chen Wang <wangchen20@iscas.ac.cn>