### PR TITLE
remove TLS_SLOT_SELF for riscv

### DIFF
--- a/libc/platform/bionic/tls_defines.h
+++ b/libc/platform/bionic/tls_defines.h
@@ -116,19 +116,25 @@
 
 #elif (defined(__riscv) && (__riscv_xlen == 64))
 
-#define MIN_TLS_SLOT              -10
+// RISC-V ELF Specification[1] specifies that: RISC-V uses Variant I as described
+// by the ELF TLS specification, with tp containing the address one past the end
+// of the TCB.
+//
+// [1]: RISC-V ELF Specification. Section: Thread Local Storage
+// https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#thread-local-storage
 
-#define TLS_SLOT_SELF             -10
-#define TLS_SLOT_THREAD_ID        -9
-#define TLS_SLOT_APP              -8 // was historically used for errno
-#define TLS_SLOT_OPENGL           -7
-#define TLS_SLOT_OPENGL_API       -6
-#define TLS_SLOT_STACK_GUARD      -5
-#define TLS_SLOT_SANITIZER        -4 // was historically used for dlerror
-#define TLS_SLOT_ART_THREAD_SELF  -3
-#define TLS_SLOT_DTV              -2
-#define TLS_SLOT_BIONIC_TLS       -1
-#define MAX_TLS_SLOT              -1 // update this value when reserving a slot
+#define MIN_TLS_SLOT             (-9) // update this value when reserving a slot
+
+#define TLS_SLOT_BIONIC_TLS      (-9)
+#define TLS_SLOT_DTV             (-8)
+#define TLS_SLOT_THREAD_ID       (-7)
+#define TLS_SLOT_APP             (-6) // was historically used for errno
+#define TLS_SLOT_OPENGL          (-5)
+#define TLS_SLOT_OPENGL_API      (-4)
+#define TLS_SLOT_STACK_GUARD     (-3)
+#define TLS_SLOT_SANITIZER       (-2) // was historically used for dlerror
+#define TLS_SLOT_ART_THREAD_SELF (-1)
+#define MAX_TLS_SLOT             (-1)
 
 #endif
 

--- a/libc/private/bionic_elf_tls.h
+++ b/libc/private/bionic_elf_tls.h
@@ -201,3 +201,16 @@ extern "C" void* TLS_GET_ADDR(const TlsIndex* ti) TLS_GET_ADDR_CCONV;
 struct bionic_tcb;
 void __free_dynamic_tls(bionic_tcb* tcb);
 void __notify_thread_exit_callbacks();
+
+#if (defined(__riscv) && (__riscv_xlen == 64))
+// TLS_DTV_OFFSET is a constant used in relocation fields, defined in RISC-V ELF Specification[1]
+// The front of the TCB contains a pointer to the DTV, and each pointer in DTV
+// points to 0x800 past the start of a TLS block to make full use of the range
+// of load/store instructions, refer to [2].
+//
+// [1]: RISC-V ELF Specification.
+// https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#constants
+// [2]: Documentation of TLS data structures
+// https://github.com/riscv-non-isa/riscv-elf-psabi-doc/issues/53
+#define TLS_DTV_OFFSET 0x800
+#endif

--- a/linker/linker.cpp
+++ b/linker/linker.cpp
@@ -2287,11 +2287,11 @@ bool do_dlsym(void* handle,
           return false;
         }
         void* tls_block = get_tls_block_for_this_thread(tls_module, /*should_alloc=*/true);
-        #if (defined(__riscv) && (__riscv_xlen == 64))
-          *symbol = static_cast<char*>(tls_block) + sym->st_value - 0x800;
-        #else
-          *symbol = static_cast<char*>(tls_block) + sym->st_value;
-        #endif
+#if (defined(__riscv) && (__riscv_xlen == 64))
+        *symbol = static_cast<char*>(tls_block) + sym->st_value - TLS_DTV_OFFSET;
+#else
+        *symbol = static_cast<char*>(tls_block) + sym->st_value;
+#endif
       } else {
         *symbol = reinterpret_cast<void*>(found->resolve_symbol_address(sym));
       }


### PR DESCRIPTION
- remove TLS_SLOT_SELF for riscv, TLS_SLOT_SELF is only used by x86
- add TLS_DTV_OFFSET to replace hardcode
- adding some comments for code

Signed-off-by: Chen Wang <wangchen20@iscas.ac.cn>