### PR TITLE
fixed TLS issues and pass unit tests

### DIFF
--- a/libc/bionic/bionic_elf_tls.cpp
+++ b/libc/bionic/bionic_elf_tls.cpp
@@ -320,11 +320,7 @@ __attribute__((noinline)) static void* tls_get_addr_slow_path(const TlsIndex* ti
     }
   }
 
-#if (defined(__riscv) && (__riscv_xlen == 64))
   return static_cast<char*>(mod_ptr) + ti->offset + TLS_DTV_OFFSET;
-#else
-  return static_cast<char*>(mod_ptr) + ti->offset;
-#endif
 }
 
 // Returns the address of a thread's TLS memory given a module ID and an offset
@@ -344,11 +340,7 @@ extern "C" void* TLS_GET_ADDR(const TlsIndex* ti) TLS_GET_ADDR_CCONV {
   if (__predict_true(generation == dtv->generation)) {
     void* mod_ptr = dtv->modules[__tls_module_id_to_idx(ti->module_id)];
     if (__predict_true(mod_ptr != nullptr)) {
-#if (defined(__riscv) && (__riscv_xlen == 64))
       return static_cast<char*>(mod_ptr) + ti->offset + TLS_DTV_OFFSET;
-#else
-      return static_cast<char*>(mod_ptr) + ti->offset;
-#endif
     }
   }
 

--- a/libc/private/bionic_elf_tls.h
+++ b/libc/private/bionic_elf_tls.h
@@ -213,4 +213,6 @@ void __notify_thread_exit_callbacks();
 // [2]: Documentation of TLS data structures
 // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/issues/53
 #define TLS_DTV_OFFSET 0x800
+#else
+#define TLS_DTV_OFFSET 0
 #endif

--- a/linker/linker.cpp
+++ b/linker/linker.cpp
@@ -371,7 +371,7 @@ static inline void* get_tls_block_for_this_thread(const soinfo_tls* si_tls, bool
     char* static_tls = reinterpret_cast<char*>(__get_bionic_tcb()) - layout.offset_bionic_tcb();
     return static_tls + tls_mod.static_offset;
   } else if (should_alloc) {
-    const TlsIndex ti { si_tls->module_id, 0 };
+    const TlsIndex ti { si_tls->module_id, static_cast<size_t>(0 - TLS_DTV_OFFSET) };
     return TLS_GET_ADDR(&ti);
   } else {
     TlsDtv* dtv = __get_tcb_dtv(__get_bionic_tcb());
@@ -2287,11 +2287,7 @@ bool do_dlsym(void* handle,
           return false;
         }
         void* tls_block = get_tls_block_for_this_thread(tls_module, /*should_alloc=*/true);
-#if (defined(__riscv) && (__riscv_xlen == 64))
-        *symbol = static_cast<char*>(tls_block) + sym->st_value - TLS_DTV_OFFSET;
-#else
         *symbol = static_cast<char*>(tls_block) + sym->st_value;
-#endif
       } else {
         *symbol = reinterpret_cast<void*>(found->resolve_symbol_address(sym));
       }

--- a/linker/linker_relocate.cpp
+++ b/linker/linker_relocate.cpp
@@ -413,7 +413,7 @@ static bool process_relocation_impl(Relocator& relocator, const rel_t& reloc) {
     case R_GENERIC_TLS_DTPREL:
       count_relocation_if<IsGeneral>(kRelocRelative);
       {
-        const ElfW(Addr) result = sym_addr + get_addend_rel();
+        const ElfW(Addr) result = sym_addr + get_addend_rel() - TLS_DTV_OFFSET;
         trace_reloc("RELO TLS_DTPREL %16p <- %16p %s",
                     rel_target, reinterpret_cast<void*>(result), sym_name);
         *static_cast<ElfW(Addr)*>(rel_target) = result;

--- a/linker/linker_relocs.h
+++ b/linker/linker_relocs.h
@@ -97,6 +97,7 @@
 #define R_GENERIC_TLS_DTPMOD    R_RISCV_TLS_DTPMOD64
 #define R_GENERIC_TLS_DTPREL    R_RISCV_TLS_DTPREL64
 #define R_GENERIC_TLS_TPREL     R_RISCV_TLS_TPREL64
+// TBD: riscv has not supported TLSDESC actually.
 #define R_GENERIC_TLSDESC       R_RISCV_TLS_GOT_HI20
 
 #endif


### PR DESCRIPTION
RISC-V ELF Specification defines each pointer in DTV
points to 0x800(TLS_DTV_OFFSET) past the start of a TLS block, which has
been suppored well for IE model but not for GD model. This change
complete TLS for GD model.

Note, in our new design, to not modify original code too much, the
pointer in DTV still point to the start of a TLS block, we just compensate
TLS_DTV_OFFSET at two places, one is in relocation(TLS_DTPREL), another
is the place where the pointer of TLS block is returned.

For x86/arm, we can think TLS_DTV_OFFSET was defined as zero to
compatible with current code-base.

Along with this change, we passed following unit cases:
- elftls_dl.access_static_tls
- elftls_dl.dtv_resize
- elftls_dl.dlsym_static_tls
- elftls_dl.dlsym_dynamic_tls

Signed-off-by: Chen Wang <wangchen20@iscas.ac.cn>