### PR TITLE
roll-back temp changes

### DIFF
--- a/tests/utils.h
+++ b/tests/utils.h
@@ -79,9 +79,7 @@ static inline bool running_with_hwasan() {
 
 static inline bool running_with_native_bridge() {
 #if defined(__BIONIC__)
-  //static const prop_info* pi = __system_property_find("ro.dalvik.vm.isa." ABI_STRING);
-  //fixme: if upgarde clang from 11 to 12
-  static const prop_info* pi = __system_property_find("ro.dalvik.vm.isa.riscv64");
+  static const prop_info* pi = __system_property_find("ro.dalvik.vm.isa." ABI_STRING);
   return pi != nullptr;
 #endif
   return false;


### PR DESCRIPTION
ABI_STRING is defined in platform/system/libbase/include/android-base/macros.h,
ABI_STRING has been defined for riscv64.

Signed-off-by: Chen Wang <wangchen20@iscas.ac.cn>