### PR TITLE
redefine ucontext

### DIFF
--- a/libc/Android.bp
+++ b/libc/Android.bp
@@ -60,6 +60,7 @@ libc_common_flags = [
     "-Werror=pointer-to-int-cast",
     "-Werror=int-to-pointer-cast",
     "-Werror=type-limits",
+    "-Werror",
 
     // Clang's exit-time destructor registration hides __dso_handle, but
     // __dso_handle needs to have default visibility on ARM32. See b/73485611.

--- a/libc/bionic/android_profiling_dynamic.cpp
+++ b/libc/bionic/android_profiling_dynamic.cpp
@@ -198,7 +198,7 @@ static void HandleSigsysSeccompOverride(int /*signal_number*/, siginfo_t* info,
 #elif defined(__aarch64__)
   ctx->uc_mcontext.regs[0] = ret;  // x0
 #elif (defined(__riscv) && (__riscv_xlen == 64))
-  //ctx->uc_mcontext.sc_regs[0] = ret;  //todo: right for riscv64?
+  ctx->uc_mcontext.__gregs[REG_A0] = ret;
 #elif defined(__i386__)
   ctx->uc_mcontext.gregs[REG_EAX] = ret;
 #elif defined(__x86_64__)

--- a/libc/include/sys/ucontext.h
+++ b/libc/include/sys/ucontext.h
@@ -367,8 +367,10 @@ typedef struct ucontext_t {
   unsigned long int  __uc_flags;
   struct ucontext_t  *uc_link;
   stack_t            uc_stack;
-  sigset_t           uc_sigmask;
-  sigset64_t         uc_sigmask64;
+  union {
+    sigset_t uc_sigmask;
+    sigset64_t uc_sigmask64;
+  };
   unsigned char      __reserved[1024 / 8 - sizeof (sigset_t)];
   mcontext_t         uc_mcontext;
 } ucontext_t;


### PR DESCRIPTION
- define sigmask of ucontext_t same as that for other ARCHs
- use a0 to store the return value
- revert -Wall for bionic build

Signed-off-by: Chen Wang <wangchen20@iscas.ac.cn>