### PR TITLE
Fix unistd.exec_argv0_null for new kernels.

### DIFF
--- a/tests/unistd_test.cpp
+++ b/tests/unistd_test.cpp
@@ -1515,11 +1515,22 @@ TEST(UNISTD_TEST, execvp_libcore_test_55017) {
 }
 
 TEST(UNISTD_TEST, exec_argv0_null) {
-  // http://b/33276926
+  // http://b/33276926 and http://b/227498625.
+  //
+  // With old kernels, bionic will see the null pointer and use "<unknown>" but
+  // with new (5.18+) kernels, the kernel will already have substituted the
+  // empty string, so we don't make any assertion here about what (if anything)
+  // comes before the first ':'.
+  //
+  // If this ever causes trouble, we could change bionic to replace _either_ the
+  // null pointer or the empty string. We could also use the actual name from
+  // readlink() on /proc/self/exe if we ever had reason to disallow programs
+  // from trying to hide like this.
+
   char* args[] = {nullptr};
   char* envs[] = {nullptr};
   ASSERT_EXIT(execve("/system/bin/run-as", args, envs), testing::ExitedWithCode(1),
-              "<unknown>: usage: run-as");
+              ": usage: run-as");
 }
 
 TEST(UNISTD_TEST, fexecve_failure) {


### PR DESCRIPTION
Cherry-pick bb1cc5a82c8e19d5f4231988ba48ce3de43ff3ed from
master of https://android.googlesource.com/platform/bionic.

More details please refer to:
https://github.com/riscv-android-src/platform-bionic/issues/31

Signed-off-by: Chen Wang <wangchen20@iscas.ac.cn>