### PR TITLE
skip ptrace testing cases

### DIFF
--- a/tests/sys_ptrace_test.cpp
+++ b/tests/sys_ptrace_test.cpp
@@ -100,6 +100,10 @@ static void check_hw_feature_supported(pid_t child, HwFeature feature) {
       GTEST_SKIP() << "Kernel reports zero hardware breakpoints";
     }
   }
+#elif (defined(__riscv) && (__riscv_xlen == 64))
+  UNUSED(child);
+  UNUSED(feature);
+  GTEST_SKIP() << "Hardware debug has not been supported in kernel";
 #else
   // We assume watchpoints and breakpoints are always supported on x86.
   UNUSED(child);


### PR DESCRIPTION
Currently kernel has not supported hardware breakpoint/watchpoint
for riscv, so just skip these cases now:
- sys_ptrace.watchpoint_stress
- sys_ptrace.watchpoint_imprecise
- sys_ptrace.hardware_breakpoint

Signed-off-by: Wang Chen <wangchen20@iscas.ac.cn>